### PR TITLE
add testloop macro

### DIFF
--- a/src/BaseTestNext.jl
+++ b/src/BaseTestNext.jl
@@ -1,7 +1,7 @@
 module BaseTestNext
 
 export @test, @test_throws
-export @testset
+export @testset, @testloop
 
 #-----------------------------------------------------------------------
 # All tests produce a result object, that may or may not be stored

--- a/src/testsets.jl
+++ b/src/testsets.jl
@@ -71,6 +71,59 @@ macro testset(args...)
 end
 
 
+
+"""
+@testloop "description \$v" for v in (...) ... end
+@testloop for x in (...), y in (...) ... end
+
+Starts a new test set, for each iteration of the loop. The description string accepts interpolation from the loop indices. If no description is provided, one is constructed based on the variables.
+"""
+macro testloop(args...)
+    # Parse arguments to do determine if any options passed in
+    if length(args) == 2
+        # Looks like description format
+        desc, testloop = args        
+        isa(desc,String) || (isa(desc,Expr) && desc.head == :string) || error("Unexpected argument to @testloop")
+        isa(testloop,Expr) && testloop.head == :for || error("Unexpected argument to @testloop")
+
+    elseif length(args) == 1
+        # No description provided
+        testloop = args[1]
+        isa(testloop,Expr) && testloop.head == :for || error("Unexpected argument to @testloop")
+        loopvars = testloop.args[1]
+        if loopvars.head == :(=)
+            # 1 variable
+            v = loopvars.args[1]
+            desc = Expr(:string,"$v = ",v)
+        else
+            # multiple variables
+            v = loopvars.args[1].args[1]
+            desc = Expr(:string,"$v = ",v) # first variable
+            for l = loopvars.args[2:end]
+                v = l.args[1]
+                push!(desc.args,", $v = ")
+                push!(desc.args,v)
+            end
+        end
+    elseif length(args) >= 3
+        error("Too many arguments to @testloop")
+    else
+        error("Too few arguments to @testloop")
+    end
+    
+    ts = gensym()
+    tests = testloop.args[2]  
+    blk = quote
+        $ts = BasicTestSet($(esc(desc)))
+        add_testset($ts)
+        $(esc(tests))
+        pop_testset()
+        finish($ts)
+    end
+    Expr(:for,esc(testloop.args[1]),blk)
+end
+
+
 #-----------------------------------------------------------------------
 # Define various helper methods for test sets
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,5 +36,19 @@ end
         @test 4 == 4
     end
     #println()
-end
 
+    @testset "loop with desc" begin
+        @testloop "loop1 $T" for T in (Float32, Float64)
+            @test 1 == T(1)
+        end
+    end
+    @testset "loops without desc" begin
+        @testloop for T in (Float32, Float64)
+            @test 1 == T(1)
+        end
+        @testloop for T in (Float32, Float64), S in (Int32,Int64)
+            @test S(1) == T(1)
+        end
+    end
+
+end


### PR DESCRIPTION
Allows construction of a testset per loop iteration

example:

```
    @testset "loop with desc" begin
        @testloop "loop1 $T" for T in (Float32, Float64)
            @test 1 == T(1)
        end
    end
    @testset "loops without desc" begin
        @testloop for T in (Float32, Float64)
            @test 1 == T(1)
        end
        @testloop for T in (Float32, Float64), S in (Int32,Int64)
            @test S(1) == T(1)
        end
    end
```

 output:

```
  loop with desc           |  Pass: 2 (100.0 %)  
    loop1 Float32          |  Pass: 1 (100.0 %)  
    loop1 Float64          |  Pass: 1 (100.0 %)  
  loops without desc       |  Pass: 6 (100.0 %)  
    T = Float32            |  Pass: 1 (100.0 %)  
    T = Float64            |  Pass: 1 (100.0 %)  
    T = Float32, S = Int32 |  Pass: 1 (100.0 %)  
    T = Float32, S = Int64 |  Pass: 1 (100.0 %)  
    T = Float64, S = Int32 |  Pass: 1 (100.0 %)  
    T = Float64, S = Int64 |  Pass: 1 (100.0 %)  
```
