### PR TITLE
adds verbose_depth setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,17 @@
 [![Build Status](https://travis-ci.org/IainNZ/BaseTestNext.jl.svg?branch=master)](https://travis-ci.org/IainNZ/BaseTestNext.jl)
 [![codecov.io](http://codecov.io/github/IainNZ/BaseTestNext.jl/coverage.svg?branch=master)](http://codecov.io/github/IainNZ/BaseTestNext.jl?branch=master)
 
-## Settings
+## Options
 
-Currently there is one setting, `:verbose_depth`, which defaults to `Inf`.
+The `@testset` macro can be given options in the form
+
+```julia
+@testset "description" option1=val begin
+    ...
+end
+```
+
+Currently there is one allowed option, `verbosity`, which defaults to `typemax(Int)`.
 BaseTestNext will report results for all `@testset`s nested less then this
 depth, and beyond that will only report errors. A value of `0` will not report
 any passed tests, `1` will show passed results for top-level `@testset`s, etc.
-Configure the setting by adding `BaseTestNext.settings[:verbose_depth] = 1` to
-your test suite.

--- a/README.md
+++ b/README.md
@@ -2,3 +2,12 @@
 
 [![Build Status](https://travis-ci.org/IainNZ/BaseTestNext.jl.svg?branch=master)](https://travis-ci.org/IainNZ/BaseTestNext.jl)
 [![codecov.io](http://codecov.io/github/IainNZ/BaseTestNext.jl/coverage.svg?branch=master)](http://codecov.io/github/IainNZ/BaseTestNext.jl?branch=master)
+
+## Settings
+
+Currently there is one setting, `:verbose_depth`, which defaults to `Inf`.
+BaseTestNext will report results for all `@testset`s nested less then this
+depth, and beyond that will only report errors. A value of `0` will not report
+any passed tests, `1` will show passed results for top-level `@testset`s, etc.
+Configure the setting by adding `BaseTestNext.settings[:verbose_depth] = 1` to
+your test suite.

--- a/src/BaseTestNext.jl
+++ b/src/BaseTestNext.jl
@@ -3,6 +3,10 @@ module BaseTestNext
 export @test, @test_throws
 export @testset, @testloop
 
+settings = Dict{Symbol, Any}(
+    :verbose_depth => Inf,
+)
+
 #-----------------------------------------------------------------------
 # All tests produce a result object, that may or may not be stored
 # depending on whether the test is part of a test set. Parameteric

--- a/src/BaseTestNext.jl
+++ b/src/BaseTestNext.jl
@@ -3,10 +3,6 @@ module BaseTestNext
 export @test, @test_throws
 export @testset, @testloop
 
-settings = Dict{Symbol, Any}(
-    :verbose_depth => Inf,
-)
-
 #-----------------------------------------------------------------------
 # All tests produce a result object, that may or may not be stored
 # depending on whether the test is part of a test set. Parameteric

--- a/src/basictestset.jl
+++ b/src/basictestset.jl
@@ -29,8 +29,6 @@ function finish(ts::BasicTestSet)
     end
     # Calculate the alignment of the test result counts
     align = _get_alignment(ts, 0)
-    # Print the outer test set header once
-    print_with_color(:white, "Test Summary:\n")
     # Recursively print a summary at every level
     _print_counts(ts, 0, align)
 end
@@ -72,7 +70,19 @@ function _print_counts(ts::BasicTestSet, depth::Int, align::Int)
             _get_test_counts(ts)
     num_test = num_pass + num_fail + num_error +
                 num_child_pass + num_child_fail + num_child_error
+    any_bad = num_child_fail > 0 || num_child_error > 0 ||
+            num_fail > 0 || num_error > 0
 
+    # Print the outer test set header at the top level, only if we're going to
+    # end up printing some results
+    if depth == 0 && (settings[:verbose_depth] > 0 || any_bad)
+        print_with_color(:white, "Test Summary:\n")
+    end
+    # top-level results have a depth of 0, but correspond to a verbose_depth
+    # setting of 1
+    if depth + 1 > settings[:verbose_depth] && !any_bad
+        return
+    end
     # Print test set header, with an alignment that ensures all
     # the test results appear above each other
     print(rpad(string("  "^depth, ts.description), align, " "), " |  ")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,5 +50,31 @@ end
             @test S(1) == T(1)
         end
     end
+end
 
+@testset "should print" verbosity=0 begin
+    @testset "should not print" begin
+        @test 1 == 1
+        @test 2 == 2
+        @test 3 == 3
+        @testset "should not print" begin
+          @test 4 == 4
+        end
+    end
+    # this should print because a child will print
+    @testset "should print" begin
+        @test 1 == 1
+        @test 2 == 2
+        @test 3 == 3
+        @testset "should print" verbosity=1 begin
+          @test 4 == 4
+        end
+    end
+    # this should print because it has an error
+    @testset "should print" begin
+        @test 1 == 1
+        @test 2 == 1
+        @test 3 == 3
+        @test 4 == 4
+    end
 end


### PR DESCRIPTION
This PR adds a module-scope settings dictionary with a `:verbose_depth` setting, which controls how deep in the `@testset` nesting we print info on successful tests.
